### PR TITLE
mock traits for manager tests

### DIFF
--- a/cpp/src/credential_traits.h
+++ b/cpp/src/credential_traits.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#define WIN32_LEAN_AND_MEAN
+
 #include <credential_type.h>
 #include <memory>
 #include <Windows.h>
@@ -20,8 +22,6 @@
 
 namespace win32::credential_store
 {
-    using unique_credential_w = std::unique_ptr<CREDENTIALW, void (*)(CREDENTIALW*)>;  
-    using unique_credentials_w = std::unique_ptr<CREDENTIALW*, void (*)(CREDENTIALW*)>;  
 
     struct credential_traits final
     {
@@ -29,6 +29,9 @@ namespace win32::credential_store
         static const DWORD SUCCESS = 0;
 
     public:
+        using unique_credential_w = std::unique_ptr<CREDENTIALW, void (*)(CREDENTIALW*)>;  
+        using unique_credentials_w = std::unique_ptr<CREDENTIALW*, void (*)(CREDENTIALW*)>;  
+
         [[nodiscard]] static DWORD cred_read(wchar_t const* id, credential_type const type, unique_credential_w& out_credential);
         [[nodiscard]] static DWORD cred_write(PCREDENTIALW credential, DWORD const flags);
         [[nodiscard]] static DWORD cred_enumerate(wchar_t const* filter, DWORD const flags, DWORD& count, CREDENTIALW**& credentials);

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -11,7 +11,14 @@ set (SOURCE
 "${CMAKE_SOURCE_DIR}/include/result_t.h"
 
  "credential_tests.cpp"
- "credential_manager_tests.cpp" "credential_builder.h" "credential_builder.cpp")
+ "credential_manager_tests.cpp" 
+ "credential_builder.h" 
+ "credential_builder.cpp" 
+ "mock_credential_factory_traits.h" 
+ "mock_credential_factory_traits.cpp" 
+ "mock_credential_traits.h" 
+ "mock_credential_traits.cpp" 
+ "invalid_test_setup_exception.h")
 
 add_executable(${TEST_PROJECT_NAME} WIN32 ${SOURCE})
 add_test(NAME ${TEST_PROJECT_NAME} COMMAND ${TEST_PROJECT_NAME})

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -11,7 +11,7 @@ set (SOURCE
 "${CMAKE_SOURCE_DIR}/include/result_t.h"
 
  "credential_tests.cpp"
- "credential_manager_tests.cpp" "credential_builder.h")
+ "credential_manager_tests.cpp" "credential_builder.h" "credential_builder.cpp")
 
 add_executable(${TEST_PROJECT_NAME} WIN32 ${SOURCE})
 add_test(NAME ${TEST_PROJECT_NAME} COMMAND ${TEST_PROJECT_NAME})

--- a/cpp/test/credential_builder.cpp
+++ b/cpp/test/credential_builder.cpp
@@ -1,0 +1,109 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#include "credential_builder.h"
+
+namespace win32::credential_store::tests
+{
+
+string_type get_id()
+{
+    return L"id";
+}
+string_type get_username()
+{
+    return L"username";
+}
+string_type get_secret()
+{
+    return L"secret";
+}
+string_type to_upper(string_type const& source)
+{
+    string_type destintiation{source};
+    for (auto& ch : destintiation) {
+        ch = static_cast<wchar_t>(towupper(ch));
+    }
+    return destintiation;
+}
+
+credential_builder initialize_builder(std::optional<credential_t> credential)
+{
+    return credential.has_value()
+        ? credential_builder::from(credential.value())
+        : credential_builder()
+            .with_id(get_id())
+            .with_username(get_username())
+            .with_secret(get_secret())
+            .with_credential_type(get_credential_type())
+            .with_persistence_type(get_persistence_type())
+            .with_last_updated(get_last_updated());
+}
+    
+credential_builder::credential_builder(credential_t credential)
+    : m_credential{credential}
+{
+}
+
+credential_builder credential_builder::from(credential_t const& credential)
+{
+    return credential_builder(credential);
+}
+
+credential_builder::optional_credential credential_builder::build_if_valid() const
+{
+    if (m_id.empty())
+        return nullopt;
+    if (m_username.empty())
+        return nullopt;
+    if (m_secret.empty())
+        return nullopt;
+    if (m_credential_type == credential_type::unknown)
+        return nullopt;
+    if (m_persistence_type == persistence_type::unknown)
+        return nullopt;
+
+    return build_credential<wchar_t>(m_id, m_username, m_secret, m_credential_type, m_persistence_type, m_last_updated).value<credential_t>();
+}
+
+credential_builder& credential_builder::with_id(string_type const& value)
+{
+    m_id = value; return *this;
+}
+
+credential_builder& credential_builder::with_username(string_type const& value)
+{
+    m_username = value; return *this;
+}
+
+credential_builder& credential_builder::with_secret(string_type const& value)
+{
+    m_secret = value; return *this;
+}
+
+credential_builder& credential_builder::with_credential_type(credential_type const value)
+{
+    m_credential_type = value; return *this;
+}
+
+credential_builder& credential_builder::with_persistence_type(persistence_type const value)
+{
+    m_persistence_type = value; return *this;
+}
+
+credential_builder& credential_builder::with_last_updated(optional_time_point const& value)
+{
+    m_last_updated = value; return *this;
+}
+
+}

--- a/cpp/test/credential_builder.h
+++ b/cpp/test/credential_builder.h
@@ -20,6 +20,21 @@
 namespace win32::credential_store::tests
 {
     using std::nullopt;
+    using credential_t = credential<wchar_t>;
+    using string_type = std::wstring;
+    using optional_string = std::optional<string_type>;
+    using optional_credential_type = std::optional<credential_type>;
+    using optional_persistence_type = std::optional<persistence_type>;
+    using optional_time_point = credential_t::optional_time_point;
+
+    [[nodiscard]] string_type get_id();
+    [[nodiscard]] string_type get_username();
+    [[nodiscard]] string_type get_secret();
+    constexpr auto get_credential_type() { return credential_type::generic; }
+    constexpr auto get_persistence_type() { return persistence_type::local_machine; }
+    constexpr auto get_last_updated() { return std::nullopt; }
+
+    [[nodiscard]] string_type to_upper(string_type const& source);
 
     class credential_builder final
     {
@@ -39,8 +54,8 @@ namespace win32::credential_store::tests
         optional_credential m_credential{};
     public:
         explicit credential_builder() = default;
-        explicit credential_builder(credential_t credential) : m_credential{credential} { }
-        [[nodiscard]] static credential_builder from(credential_t const& credential) { return credential_builder(credential); }
+        explicit credential_builder(credential_t credential); 
+        [[nodiscard]] static credential_builder from(credential_t const& credential);
 
         template <typename TArg>
         [[nodiscard]] constexpr credential_builder& set_value_and_return(TArg& destination, TArg& source)
@@ -48,31 +63,18 @@ namespace win32::credential_store::tests
             destination = source;
             return *this;
         }
+        [[nodiscard]] optional_credential build_if_valid() const;
 
-        credential_builder& with_id(string_type const& value) {m_id = value; return *this;}
-        credential_builder& with_username(string_type const& value) {m_username = value; return *this;}
-        credential_builder& with_secret(string_type const& value) {m_secret = value; return *this;}
-        credential_builder& with_credential_type(credential_type const value) {m_credential_type = value; return *this;}
-        credential_builder& with_persistence_type(persistence_type const value) {m_persistence_type = value; return *this;}
-        credential_builder& with_last_updated(optional_time_point const& value) {m_last_updated = value; return *this;}
-
-        optional_credential build_if_valid()
-        {
-            if (m_id.empty())
-                return nullopt;
-            if (m_username.empty())
-                return nullopt;
-            if (m_secret.empty())
-                return nullopt;
-            if (m_credential_type == credential_type::unknown)
-                return nullopt;
-            if (m_persistence_type == persistence_type::unknown)
-                return nullopt;
-
-            return build_credential<wchar_t>(m_id, m_username, m_secret, m_credential_type, m_persistence_type, m_last_updated).value<credential_t>();
-        }
+        [[nodiscard]] credential_builder& with_id(string_type const& value);
+        [[nodiscard]] credential_builder& with_username(string_type const& value);
+        [[nodiscard]] credential_builder& with_secret(string_type const& value);
+        [[nodiscard]] credential_builder& with_credential_type(credential_type const value);
+        [[nodiscard]] credential_builder& with_persistence_type(persistence_type const value);
+        [[nodiscard]] credential_builder& with_last_updated(optional_time_point const& value);
 
     };
+
+    [[nodiscard]] credential_builder initialize_builder(std::optional<credential_t> credential = nullopt);
 
 
 }

--- a/cpp/test/credential_tests.cpp
+++ b/cpp/test/credential_tests.cpp
@@ -25,42 +25,6 @@ using std::nullopt;
 namespace win32::credential_store::tests
 {
 
-using credential_t = credential<wchar_t>;
-using string_type = std::wstring;
-using optional_string = std::optional<string_type>;
-using optional_credential_type = std::optional<credential_type>;
-using optional_persistence_type = std::optional<persistence_type>;
-using optional_time_point = credential_t::optional_time_point;
-
-[[nodiscard]] string_type to_upper(string_type const& source)
-{
-    string_type destintiation{source};
-    for (auto& ch : destintiation) {
-        ch = static_cast<wchar_t>(towupper(ch));
-    }
-    return destintiation;
-}
-
-string_type get_id() { return L"id"; }
-string_type get_username() { return L"username"; }
-string_type get_secret() { return L"secret"; }
-constexpr auto get_credential_type() { return credential_type::generic; }
-constexpr auto get_persistence_type() { return persistence_type::local_machine; }
-constexpr auto get_last_updated() { return std::nullopt; }
-
-[[nodiscard]] credential_builder initialize_builder(std::optional<credential_t> credential = nullopt)
-{
-    return credential.has_value() 
-        ? credential_builder::from(credential.value())
-        : credential_builder()
-            .with_id(get_id())
-            .with_username(get_username())
-            .with_secret(get_secret())
-            .with_credential_type(get_credential_type())
-            .with_persistence_type(get_persistence_type())
-            .with_last_updated(get_last_updated());
-}
-
 credential_t make_credential()
 {
     return build_credential<wchar_t>(get_id(), get_username(), get_secret(), get_credential_type(), get_persistence_type(), get_last_updated())

--- a/cpp/test/invalid_test_setup_exception.h
+++ b/cpp/test/invalid_test_setup_exception.h
@@ -1,0 +1,30 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#pragma once
+
+#include <exception>
+
+namespace win32::credential_store::tests
+{
+
+    class invalid_test_setup_exception final : public std::exception
+    {
+    public:
+        explicit invalid_test_setup_exception(char const* message) noexcept
+            : exception(message)
+        {
+        }
+    };
+
+}

--- a/cpp/test/mock_credential_factory_traits.cpp
+++ b/cpp/test/mock_credential_factory_traits.cpp
@@ -16,19 +16,19 @@
 
 namespace win32::credential_store::tests
 {
-    mock_credential_factory_traits::credential_t* mock_credential_factory_traits::m_mock_result_ptr = nullptr;
+    mock_credential_factory_traits::credential_t* mock_credential_factory_traits::s_mock_result_ptr = nullptr;
 
     mock_credential_factory_traits::credential_t mock_credential_factory_traits::from_win32_credential(CREDENTIALW const* const credential_ptr)
     {
-        if (m_mock_result_ptr == nullptr)
+        if (s_mock_result_ptr == nullptr)
             throw invalid_test_setup_exception("mock result not initialized");
 
         static_cast<void>(credential_ptr);
-        return *m_mock_result_ptr;
+        return *s_mock_result_ptr;
 
     }
-    void mock_credential_factory_traits::set_credential(credential_t* value)
+    void mock_credential_factory_traits::set_credential(credential_t* value) noexcept
     {
-        m_mock_result_ptr = value;
+        s_mock_result_ptr = value;
     }
 }

--- a/cpp/test/mock_credential_factory_traits.cpp
+++ b/cpp/test/mock_credential_factory_traits.cpp
@@ -1,0 +1,34 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#include "mock_credential_factory_traits.h"
+#include "invalid_test_setup_exception.h"
+
+namespace win32::credential_store::tests
+{
+    mock_credential_factory_traits::credential_t* mock_credential_factory_traits::m_mock_result_ptr = nullptr;
+
+    mock_credential_factory_traits::credential_t mock_credential_factory_traits::from_win32_credential(CREDENTIALW const* const credential_ptr)
+    {
+        if (m_mock_result_ptr == nullptr)
+            throw invalid_test_setup_exception("mock result not initialized");
+
+        static_cast<void>(credential_ptr);
+        return *m_mock_result_ptr;
+
+    }
+    void mock_credential_factory_traits::set_credential(credential_t* value)
+    {
+        m_mock_result_ptr = value;
+    }
+}

--- a/cpp/test/mock_credential_factory_traits.h
+++ b/cpp/test/mock_credential_factory_traits.h
@@ -1,0 +1,34 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <Windows.h>
+#include <wincred.h>
+#include <credential.h>
+
+namespace win32::credential_store::tests
+{
+    struct mock_credential_factory_traits final
+    {
+        using credential_t = credential<wchar_t>;
+
+        [[nodiscard]] static credential_t from_win32_credential(CREDENTIALW const * const credential_ptr);
+        [[nodiscard]] static void set_credential(credential_t* value);
+
+    private:
+        static credential_t* m_mock_result_ptr;
+    };
+}

--- a/cpp/test/mock_credential_factory_traits.h
+++ b/cpp/test/mock_credential_factory_traits.h
@@ -26,9 +26,9 @@ namespace win32::credential_store::tests
         using credential_t = credential<wchar_t>;
 
         [[nodiscard]] static credential_t from_win32_credential(CREDENTIALW const * const credential_ptr);
-        [[nodiscard]] static void set_credential(credential_t* value);
+        static void set_credential(credential_t* value) noexcept;
 
     private:
-        static credential_t* m_mock_result_ptr;
+        static credential_t* s_mock_result_ptr;
     };
 }

--- a/cpp/test/mock_credential_traits.cpp
+++ b/cpp/test/mock_credential_traits.cpp
@@ -12,8 +12,75 @@
 // 
 
 #include "mock_credential_traits.h"
+#include "../src/credential_traits.h"
 
-namespace win32::creddential_store::tests
+namespace win32::credential_store::tests
 {
+    //using unique_credential_w = std::unique_ptr<CREDENTIALW, void (*)(CREDENTIALW*)>;  
+    CREDENTIALW* MOCK_CREDENTIAL_ADDRESS = reinterpret_cast<CREDENTIALW*>(0x1234);
 
+    mock_credential_traits::credential_t* mock_credential_traits::s_mock_result_ptr = nullptr;
+
+    DWORD mock_credential_traits::s_cred_read_result = 0UL;
+    DWORD mock_credential_traits::s_cred_write_result = 0UL;
+    DWORD mock_credential_traits::s_cred_enumerate_result = 0UL;
+    DWORD mock_credential_traits::s_cred_delete_result = 0UL;
+
+    DWORD mock_credential_traits::cred_read(wchar_t const*, credential_type const, unique_credential_w& out_credential)
+    {
+        out_credential = unique_credential_w(MOCK_CREDENTIAL_ADDRESS, mock_credential_traits::credential_deleter);
+
+        return s_cred_read_result;
+    }
+    DWORD mock_credential_traits::cred_write(PCREDENTIALW, DWORD const)
+    {
+        return s_cred_write_result;
+    }
+    DWORD mock_credential_traits::cred_enumerate(wchar_t const*, DWORD const, DWORD& count, CREDENTIALW**& credentials)
+    {
+        // not implemented yet, count and credentials will be used eventually
+        static_cast<void>(count);
+        credentials = nullptr;
+        return s_cred_enumerate_result;
+    }
+    DWORD mock_credential_traits::cred_delete(wchar_t const*, credential_type const)
+    {
+        return s_cred_delete_result;
+    }
+    void mock_credential_traits::credential_deleter(CREDENTIALW*)
+    {
+        // ... ignore ...
+    }
+    void mock_credential_traits::credential_deleter(CREDENTIALW**)
+    {
+        // ... ignore ...
+    }
+    DWORD mock_credential_traits::to_dword(credential_type const type)
+    {
+        return credential_traits::to_dword(type);
+    }
+    DWORD mock_credential_traits::to_dword(persistence_type const type)
+    {
+        return credential_traits::to_dword(type);
+    }
+    void mock_credential_traits::set_credential(credential_t* value) noexcept
+    {
+        s_mock_result_ptr = value;
+    }
+    void mock_credential_traits::set_cred_read_result(DWORD const value) noexcept
+    {
+        s_cred_read_result = value;
+    }
+    void mock_credential_traits::set_cred_write_result(DWORD const value) noexcept
+    {
+        s_cred_write_result = value;
+    }
+    void mock_credential_traits::set_cred_enumerate_result(DWORD const value) noexcept
+    {
+        s_cred_enumerate_result = value;
+    }
+    void mock_credential_traits::set_cred_delete_result(DWORD const value) noexcept
+    {
+        s_cred_delete_result = value;
+    }
 }

--- a/cpp/test/mock_credential_traits.cpp
+++ b/cpp/test/mock_credential_traits.cpp
@@ -1,0 +1,19 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#include "mock_credential_traits.h"
+
+namespace win32::creddential_store::tests
+{
+
+}

--- a/cpp/test/mock_credential_traits.h
+++ b/cpp/test/mock_credential_traits.h
@@ -13,9 +13,44 @@
 
 #pragma once
 
-namespace win32::creddential_store::tests
+#include <memory>
+#include <Windows.h>
+#include <wincred.h>
+#include <credential.h>
+
+namespace win32::credential_store::tests
 {
 
+    struct mock_credential_traits final
+    {
+        using unique_credential_w = std::unique_ptr<CREDENTIALW, void (*)(CREDENTIALW*)>;  
+        using unique_credentials_w = std::unique_ptr<CREDENTIALW*, void (*)(CREDENTIALW*)>;  
+        using credential_t = credential<wchar_t>;
+
+        static const DWORD SUCCESS = 0;
+        static credential_t* s_mock_result_ptr;
+        static DWORD s_cred_read_result;
+        static DWORD s_cred_write_result;
+        static DWORD s_cred_enumerate_result;
+        static DWORD s_cred_delete_result;
+
+        [[nodiscard]] static DWORD cred_read(wchar_t const*, credential_type const, unique_credential_w& out_credential);
+        [[nodiscard]] static DWORD cred_write(PCREDENTIALW, DWORD const);
+        [[nodiscard]] static DWORD cred_enumerate(wchar_t const*, DWORD const, DWORD& count, CREDENTIALW**& credentials);
+        [[nodiscard]] static DWORD cred_delete(wchar_t const*, credential_type const);
+
+        static void credential_deleter(CREDENTIALW*);
+        static void credential_deleter(CREDENTIALW**);
+
+        [[nodiscard]] static DWORD to_dword(credential_type const type);
+        [[nodiscard]] static DWORD to_dword(persistence_type const type);
+
+        static void set_credential(credential_t* value) noexcept;
+        static void set_cred_read_result(DWORD const value) noexcept;
+        static void set_cred_write_result(DWORD const value) noexcept;
+        static void set_cred_enumerate_result(DWORD const value) noexcept;
+        static void set_cred_delete_result(DWORD const value) noexcept;
+    };
 
 
 }

--- a/cpp/test/mock_credential_traits.h
+++ b/cpp/test/mock_credential_traits.h
@@ -1,0 +1,21 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#pragma once
+
+namespace win32::creddential_store::tests
+{
+
+
+
+}


### PR DESCRIPTION
## Changes

- code tidy up - shifted code from credential_test to credential_builder - shifted code from credential_builder header to cpp file
- adding mock traits for manager tests - factory_tratis complete - files added for mock_credential_traits but no implementation yet
- moved unique_credential into traits - moved using statements into class level from namespace level so it can be part of the trait - further implementation of mock traits

## Tests

- basic smoke test, existing unit tests