### PR TITLE
either improvements + unit tests

### DIFF
--- a/cpp/include/credential.h
+++ b/cpp/include/credential.h
@@ -17,10 +17,10 @@
 #include <chrono>
 #include <tuple>
 #include <optional>
-#include <utility>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 #include <Windows.h>
-#include <wincred.h>
 
 #include <either.h>
 #include <result_t.h>

--- a/cpp/include/credential_manager.h
+++ b/cpp/include/credential_manager.h
@@ -13,9 +13,7 @@
 
 #pragma once
 
-#include <vector>
 #include <memory>
-#include <optional>
 #include <credential.h>
 #include <credential_type.h>
 #include <result_t.h>
@@ -37,11 +35,12 @@ namespace win32::credential_store
         std::unique_ptr<credential_manager_impl> m_p_impl;
 #       pragma warning(pop)
 
+
     public:
         /// <summary>
         /// Returns all credentials from the Users credential set
         /// </summary>
-        [[nodiscard]] std::vector<credential_t> get_credentials() const override;
+        [[nodiscard]] credentials_or_error_detail get_credentials() const override;
 
         /// <summary>
         /// Adds or updates <paramref name="credential"/> to Win32
@@ -60,7 +59,7 @@ namespace win32::credential_store
         /// <exception cref="std::system_error">
         /// if native api returns error
         /// </exception>
-        [[nodiscard]] credential_or_error_detail find(wchar_t const* id, credential_type type) const override;
+        [[nodiscard]]  credential_or_error_detail find(wchar_t const* id, credential_type type) const override;
 
         /// <summary>
         /// Returns all credentials matching wildcard based <paramref name="filter"/>
@@ -68,7 +67,7 @@ namespace win32::credential_store
         /// <param name="filter">filter using wildcards</param>
         /// <param name="search_all">if true all credentials are searched</param>
         /// <returns>vector containing all credentials returned </returns>
-        [[nodiscard]] std::vector<credential_t> find(wchar_t const* filter, bool const search_all) const override;
+        [[nodiscard]] credentials_or_error_detail find(wchar_t const* filter, bool const search_all) const override;
 
         /// <summary>
         /// removes a credential from the user's credential set

--- a/cpp/include/credential_manager_interface.h
+++ b/cpp/include/credential_manager_interface.h
@@ -26,6 +26,7 @@ namespace win32::credential_store
         using credential_t = credential<wchar_t>;
         using optional_credential_t = std::optional<credential_t>;
         using credential_or_error_detail = either<credential<wchar_t>, result_t>;
+        using credentials_or_error_detail = either<std::vector<credential_t>, result_t>;
 
         credential_manager_interface(credential_manager_interface const&) = delete;
         virtual ~credential_manager_interface() = default;
@@ -33,7 +34,7 @@ namespace win32::credential_store
         /// <summary>
         /// Returns all credentials from the Users credential set
         /// </summary>
-        [[nodiscard]] virtual std::vector<credential_t> get_credentials() const = 0;
+        [[nodiscard]] virtual credentials_or_error_detail get_credentials() const = 0;
 
         /// <summary>
         /// Adds or updates <paramref name="credential"/> to Win32
@@ -60,7 +61,7 @@ namespace win32::credential_store
         /// <param name="filter">filter using wildcards</param>
         /// <param name="search_all">if true all credentials are searched</param>
         /// <returns>vector containing all credentials returned </returns>
-        [[nodiscard]] virtual std::vector<credential_t> find(wchar_t const* filter, bool const search_all) const = 0;
+        [[nodiscard]] virtual credentials_or_error_detail find(wchar_t const* filter, bool const search_all) const = 0;
 
         /// <summary>
         /// removes a credential from the user's credential set

--- a/cpp/include/either.h
+++ b/cpp/include/either.h
@@ -108,13 +108,7 @@ namespace win32::credential_store
         }
 
         template <typename TValueType>
-        [[nodiscard]] constexpr TValueType& value_or(TValueType& else_value)
-        {
-            static_assert(std::is_same_v<TValueType, TLeft> || std::is_same_v<TValueType, TRight>, "invalid type");
-            return m_left_value.value_or(else_value);
-        }
-        template <typename TValueType>
-        [[nodiscard]] constexpr TValueType const& value_or(TValueType const& else_value) const
+        [[nodiscard]] constexpr TValueType value_or(TValueType&& else_value) &&
         {
             static_assert(std::is_same_v<TValueType, TLeft> || std::is_same_v<TValueType, TRight>, "invalid type");
             if constexpr (std::is_same_v<TValueType, TLeft>) {
@@ -123,52 +117,33 @@ namespace win32::credential_store
                 return m_right_value.value_or(else_value);
             }
         }
-        template <typename TValueType, typename TSupplier>
-        [[nodiscard]] constexpr TValueType& value_or(TSupplier const& supplier)
+        template <typename TValueType>
+        [[nodiscard]] constexpr TValueType value_or(TValueType&& else_value) const&
         {
-            if (has_value<TValueType>()) 
-                return value<TValueType>();
-            return supplier();
-        }
-        template <typename TValueType, typename TSupplier>
-        [[nodiscard]] constexpr TValueType const& value_or(TSupplier const& supplier) const
-        {
-            if (has_value<TValueType>()) 
-                return value<TValueType>();
-            return supplier();
-        }
-        /*
-         * TODO: fix the template issues prventing this from specializing
-        template <typename TValueType, typename TSupplier,
-            std::enable_if_t<std::is_trivially_copy_assignable_v<TLeft>, int> = 0>
-        [[nodiscard]] constexpr TValueType value_or(TSupplier const& supplier)
-        {
-            if (has_value<TValueType>()) 
-                return error<TValueType>();
-            return supplier();
-        }
-        */
-
-        [[nodiscard]] constexpr explicit operator TLeft&() 
-        {
-            return m_left_value.error();
-        }
-        [[nodiscard]] constexpr explicit operator TLeft const&() const
-        {
-            return m_left_value.error();
+            static_assert(std::is_same_v<TValueType, TLeft> || std::is_same_v<TValueType, TRight>, "invalid type");
+            if constexpr (std::is_same_v<TValueType, TLeft>) {
+                return m_left_value.value_or(else_value);
+            } else {
+                return m_right_value.value_or(else_value);
+            }
         }
 
-        constexpr explicit operator TRight&() 
+        [[nodiscard]] constexpr explicit operator TLeft&()&
         {
-            return m_right_value.error();
+            return m_left_value.value();
         }
-        constexpr explicit operator TRight const&() const
+        [[nodiscard]] constexpr explicit operator TLeft const&() const&
         {
-            return m_right_value.error();
+            return m_left_value.value();
         }
-        constexpr TLeft& right_value_or(TLeft& else_value)
+
+        constexpr explicit operator TRight&() &
         {
-            return m_right_value.value_or(else_value);
+            return m_right_value.value();
+        }
+        constexpr explicit operator TRight const&() const&
+        {
+            return m_right_value.value();
         }
     };
 

--- a/cpp/src/credential_manager.cpp
+++ b/cpp/src/credential_manager.cpp
@@ -30,9 +30,10 @@ credential_manager::~credential_manager()
     m_p_impl.reset();
 }
 
-std::vector<credential_manager::credential_t> credential_manager::get_credentials() const
+credential_manager::credentials_or_error_detail credential_manager::get_credentials() const
 {
     if (!static_cast<bool>(m_p_impl)) {
+        return credentials_or_error_detail(result_t::from_error_code(std::errc::owner_dead));
     }
 
     return m_p_impl->get_credentials();
@@ -49,15 +50,15 @@ result_t credential_manager::add_or_update(credential_t const& credential) const
 credential_manager::credential_or_error_detail credential_manager::find(wchar_t const* id, credential_type type) const
 {
     if (!static_cast<bool>(m_p_impl)) {
-        return make_right<credential_t, result_t>(result_t::from_error_code(std::errc::owner_dead));
+        return credential_or_error_detail(result_t::from_error_code(std::errc::owner_dead));
     }
     return m_p_impl->find(id, type);
 }
 
-std::vector<credential_manager::credential_t> credential_manager::find(wchar_t const* filter, bool const search_all) const
+credential_manager::credentials_or_error_detail credential_manager::find(wchar_t const* filter, bool const search_all) const
 {
     if (!static_cast<bool>(m_p_impl)) {
-        return std::vector<credential_t>();
+        return credentials_or_error_detail(result_t::from_error_code(std::errc::owner_dead));
     }
     return m_p_impl->find(filter, search_all);
 }

--- a/cpp/src/credential_manager_impl.h
+++ b/cpp/src/credential_manager_impl.h
@@ -14,27 +14,27 @@
 #pragma once
 
 #include <optional>
-#include <vector>
 #include <credential.h>
+#include <credential_manager_interface.h>
 
 namespace win32::credential_store
 {
     class credential_manager_impl 
     {
     public:
-        using credential_t = credential<wchar_t>;
-        using optional_credential_t = std::optional<credential_t>;
-        using credential_or_error_detail = either<credential_t, result_t>;
-        using credentials_or_error_detail = either<std::vector<credential_t>, result_t>;
+        using credential_t = credential_manager_interface::credential_t; //credential<wchar_t>;
+        using optional_credential_t = credential_manager_interface::optional_credential_t; // std::optional<credential_t>;
+        using credential_or_error_detail = credential_manager_interface::credential_or_error_detail; // either<credential_t, result_t>;
+        using credentials_or_error_detail = credential_manager_interface::credentials_or_error_detail; // either<std::vector<credential_t>, result_t>;
 
         credential_manager_impl(const credential_manager_impl& other) = delete;
         credential_manager_impl(credential_manager_impl&& other) noexcept = delete;
         virtual ~credential_manager_impl() = default;
 
-        [[nodiscard]] virtual std::vector<credential_t> get_credentials() const = 0;
+        [[nodiscard]] virtual credentials_or_error_detail get_credentials() const = 0;
         [[nodiscard]] virtual result_t add_or_update(credential_t const& credential) = 0;
         [[nodiscard]] virtual credential_or_error_detail find(wchar_t const* id, credential_type type) const = 0;
-        [[nodiscard]] virtual std::vector<credential_t> find(wchar_t const* filter, bool search_all) const = 0;
+        [[nodiscard]] virtual credentials_or_error_detail find(wchar_t const* filter, bool search_all) const = 0;
         [[nodiscard]] virtual result_t remove(credential_t const& credential) const = 0;
         [[nodiscard]] virtual result_t remove(wchar_t const* id, credential_type type) const = 0;
 

--- a/cpp/src/credential_manager_impl.h
+++ b/cpp/src/credential_manager_impl.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <optional>
+#include <vector>
 #include <credential.h>
 
 namespace win32::credential_store
@@ -24,6 +25,7 @@ namespace win32::credential_store
         using credential_t = credential<wchar_t>;
         using optional_credential_t = std::optional<credential_t>;
         using credential_or_error_detail = either<credential_t, result_t>;
+        using credentials_or_error_detail = either<std::vector<credential_t>, result_t>;
 
         credential_manager_impl(const credential_manager_impl& other) = delete;
         credential_manager_impl(credential_manager_impl&& other) noexcept = delete;

--- a/cpp/src/credential_manager_impl_using_traits.h
+++ b/cpp/src/credential_manager_impl_using_traits.h
@@ -131,6 +131,7 @@ namespace win32::credential_store
             credentials_container container;
 
             auto const result = CREDENTIAL_TRAITS::cred_enumerate(filter, flags, container.count, container.credentials); 
+            // TODO: change method to return either vector, or result_t
             if (result != SUCCESS) {
                 throw std::system_error(std::error_code(result, std::system_category()));
             }

--- a/cpp/src/credential_manager_impl_using_traits.h
+++ b/cpp/src/credential_manager_impl_using_traits.h
@@ -16,7 +16,6 @@
 #define WIN32_LEAN_AND_MEAN 
 
 #include <system_error>
-#include <optional>
 #include <credential.h>
 #include "credential_manager_impl.h"
 #include "credential_traits.h"
@@ -31,10 +30,7 @@ namespace win32::credential_store
     class credential_manager_impl_using_traits final : public credential_manager_impl
     {
     public:
-        using credential_t = credential<wchar_t>;
-        using optional_credential_t = std::optional<credential<wchar_t>>;
-
-        [[nodiscard]] std::vector<credential_t> get_credentials() const override
+        [[nodiscard]] credentials_or_error_detail get_credentials() const override
         {
             return get_credentials(nullptr, true);
         }
@@ -66,14 +62,11 @@ namespace win32::credential_store
                 result == SUCCESS) {
                 return make_left<credential_t, result_t>(CREDENTIAL_FACTORY_TRAITS::from_win32_credential(credential.get()));
 
-            } else if (result == ERROR_NOT_FOUND) {
-                return make_right<credential_t, result_t>(result_t::from_win32_error(result));
-
             } else {
                 return make_right<credential_t, result_t>(result_t::from_win32_error(result));
             }
         }
-        [[nodiscard]] std::vector<credential_t> find(wchar_t const* filter, const bool search_all) const override
+        [[nodiscard]] credentials_or_error_detail find(wchar_t const* filter, const bool search_all) const override
         {
             return get_credentials(filter, search_all);
         }
@@ -106,13 +99,14 @@ namespace win32::credential_store
             return string == nullptr || wcslen(string) == 0;
         }
 
-        [[nodiscard]] std::vector<credential_t> get_credentials(wchar_t const* filter, const bool search_all) const 
+        [[nodiscard]] credentials_or_error_detail get_credentials(wchar_t const* filter, const bool search_all) const 
         {
-            std::vector<credential_t> matches;
+            using credentials_t = std::vector<credential_t>;
+            credentials_t matches;
 
             auto flags = search_all ? CRED_ENUMERATE_ALL_CREDENTIALS : 0;
 
-            struct credentials_container
+            struct credentials_container final
             {
                 credentials_container() = default;
                 credentials_container(credentials_container const&) = delete;
@@ -133,14 +127,15 @@ namespace win32::credential_store
             auto const result = CREDENTIAL_TRAITS::cred_enumerate(filter, flags, container.count, container.credentials); 
             // TODO: change method to return either vector, or result_t
             if (result != SUCCESS) {
-                throw std::system_error(std::error_code(result, std::system_category()));
+                return credentials_or_error_detail(result_t::from_win32_error(result));
             }
 
             for (DWORD i = 0; i< container.count; i++) {
                 matches.push_back(CREDENTIAL_FACTORY_TRAITS::from_win32_credential(container.credentials[i]));
             }
 
-            return matches;
+            return make_left<credentials_t, result_t>(std::move(matches));
+            //return credentials_or_error_detail(std::move(matches));
         }
 
     };

--- a/cpp/src/credential_store_cli/credential_executor.cpp
+++ b/cpp/src/credential_store_cli/credential_executor.cpp
@@ -115,7 +115,11 @@ void credential_executor::list(std::vector<std::string_view> const& arguments) c
 {
     static_cast<void>(arguments);
 
-    auto credentials =  m_manager.get_credentials();
+    using credentials_t = std::vector<credential<wchar_t>>;
+
+    auto credentials =  m_manager
+        .get_credentials()
+        .value_or(credentials_t());
 
     for (auto const& credential : credentials) {
         print_credential(credential);

--- a/cpp/test/credential_builder.cpp
+++ b/cpp/test/credential_builder.cpp
@@ -12,6 +12,10 @@
 // 
 
 #include "credential_builder.h"
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <sstream>
 
 namespace win32::credential_store::tests
 {
@@ -116,6 +120,29 @@ credential_t make_credential()
 {
     return build_credential<wchar_t>(get_id(), get_username(), get_secret(), get_credential_type(), get_persistence_type(), get_last_updated())
         .value<credential_t>();
+}
+
+std::vector<credential_t> make_credentials(size_t const size)
+{
+    using std::vector;
+    using std::generate_n;
+    using std::back_inserter;
+    using std::wstringstream;
+
+    vector<credential_t> credentials;
+    int i = 0;
+    generate_n(back_inserter(credentials), size, 
+        [&i]() -> credential_t
+        {
+            wstringstream builder{};
+            builder << get_id() << ++i;
+            return initialize_builder()
+                .with_id(builder.str())
+                .build_if_valid()
+                .value();
+        });
+
+    return credentials;
 }
 
 }

--- a/cpp/test/credential_builder.h
+++ b/cpp/test/credential_builder.h
@@ -15,6 +15,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 #include <credential.h>
 
 namespace win32::credential_store::tests
@@ -75,5 +76,5 @@ namespace win32::credential_store::tests
 
     [[nodiscard]] credential_builder initialize_builder(std::optional<credential_t> credential = nullopt);
     [[nodiscard]] credential_t make_credential();
-
+    [[nodiscard]] std::vector<credential_t> make_credentials(size_t const size);
 }

--- a/cpp/test/credential_manager_tests.cpp
+++ b/cpp/test/credential_manager_tests.cpp
@@ -64,21 +64,6 @@ TEST(credential_manager, add_or_update__returns_error__api_returns_error)
     ASSERT_TRUE(result.error_equals(42UL));
 }
 
-TEST(credential_manager, find__returns_credential__when_match_found)
-{
-    auto credential{make_credential()};
-    credential_manager_test const manager;
-    mock_credential_traits::set_cred_read_result(ERROR_SUCCESS);
-    mock_credential_factory_traits::set_credential(&credential);
-    auto const* id = L"ARBITRARY";
-    auto const type = credential_type::generic;
-
-    auto const result = manager.find(id, type);
-
-    EXPECT_TRUE(result.has_value<credential_t>());
-    ASSERT_EQ(result.value<credential_t>(), credential);
-}
-
 TEST(credential_manager, find__returns_not_found__when_api_returns_not_found)
 {
     mock_credential_traits::set_cred_read_result(ERROR_NOT_FOUND);

--- a/cpp/test/mock_credential_traits.cpp
+++ b/cpp/test/mock_credential_traits.cpp
@@ -36,7 +36,7 @@ namespace win32::credential_store::tests
     {
         return s_cred_write_result;
     }
-    DWORD mock_credential_traits::cred_enumerate(wchar_t const*, DWORD const, DWORD& count, CREDENTIALW**& credentials)
+    DWORD mock_credential_traits::cred_enumerate(wchar_t const*, DWORD const flags, DWORD& count, CREDENTIALW**& credentials)
     {
         // not implemented yet, count and credentials will be used eventually
         static_cast<void>(count);

--- a/cpp/test/mock_credential_traits.cpp
+++ b/cpp/test/mock_credential_traits.cpp
@@ -40,6 +40,7 @@ namespace win32::credential_store::tests
     {
         // not implemented yet, count and credentials will be used eventually
         static_cast<void>(count);
+        static_cast<void>(flags);
         credentials = nullptr;
         return s_cred_enumerate_result;
     }

--- a/cpp/test/mock_credential_traits.h
+++ b/cpp/test/mock_credential_traits.h
@@ -34,9 +34,12 @@ namespace win32::credential_store::tests
         static DWORD s_cred_enumerate_result;
         static DWORD s_cred_delete_result;
 
+        static DWORD s_enumerate_count;
+        static DWORD s_enumerate_flags;
+
         [[nodiscard]] static DWORD cred_read(wchar_t const*, credential_type const, unique_credential_w& out_credential);
         [[nodiscard]] static DWORD cred_write(PCREDENTIALW, DWORD const);
-        [[nodiscard]] static DWORD cred_enumerate(wchar_t const*, DWORD const, DWORD& count, CREDENTIALW**& credentials);
+        [[nodiscard]] static DWORD cred_enumerate(wchar_t const*, DWORD const flags, DWORD& count, CREDENTIALW**& credentials);
         [[nodiscard]] static DWORD cred_delete(wchar_t const*, credential_type const);
 
         static void credential_deleter(CREDENTIALW*);


### PR DESCRIPTION
## Changes

- code tidy up - shifted code from credential_test to credential_builder - shifted code from credential_builder header to cpp file
- adding mock traits for manager tests - factory_tratis complete - files added for mock_credential_traits but no implementation yet
- moved unique_credential into traits - moved using statements into class level from namespace level so it can be part of the trait - further implementation of mock traits
- updated shared library CMakeLists.txt - now builds dll, includes not yet updated with any export details but definition has been added
- added header file with #define exports - added extra definition to shared library to further distinguish between static library and shared library
- added export usage to credential manager - added WIN32_CREDENTIAL_STORE_EXPORT to classes, functions, ... to be exported from shared library of credential manager - updated test project to use shared library
- added unit tests - make error_equals const - added unit tests for add_or_update in credential manager - moved make_credential to credential_builder
- start of update to find : vector<credential_t> - intention is to change the return value to either<vector<credential_t>, result_t> to allow returning error rather than throwing exception - additional unit tests for find : either<credential_t, result_t> - added make_credentials which creates a vector of credential_t, not sure if it'll actually be used or not
- reworked find : vector<credential_t> - updated find : vector<credentiaL_t> to return either<vector, result_t> to handle errors without the need for exceptions corrections to either - removed overloads using supplier - updated the remaining implementation to match value_or for optional -
- removed duplicate test

## Tests

- verify it still compiles
- existing and new unit tests
