### PR TITLE
unit tests + minor tweaks

### DIFF
--- a/cpp/include/either.h
+++ b/cpp/include/either.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <functional>
 #include <optional>
 
 namespace win32::credential_store 
@@ -108,6 +109,16 @@ namespace win32::credential_store
         }
 
         template <typename TValueType>
+        [[nodiscard]] constexpr TValueType value_or(std::function<TValueType(*)()> const& supplier) &&
+        {
+            static_assert(std::is_same_v<TValueType, TLeft> || std::is_same_v<TValueType, TRight>, "invalid type");
+            if constexpr (std::is_same_v<TValueType, TLeft>) {
+                return m_left_value.value_or(supplier());
+            } else {
+                return m_right_value.value_or(supplier());
+            }
+        }
+        template <typename TValueType>
         [[nodiscard]] constexpr TValueType value_or(TValueType&& else_value) &&
         {
             static_assert(std::is_same_v<TValueType, TLeft> || std::is_same_v<TValueType, TRight>, "invalid type");
@@ -115,6 +126,16 @@ namespace win32::credential_store
                 return m_left_value.value_or(else_value);
             } else {
                 return m_right_value.value_or(else_value);
+            }
+        }
+        template <typename TValueType>
+        [[nodiscard]] constexpr TValueType value_or(std::function<TValueType(*)()> const& supplier) const&
+        {
+            static_assert(std::is_same_v<TValueType, TLeft> || std::is_same_v<TValueType, TRight>, "invalid type");
+            if constexpr (std::is_same_v<TValueType, TLeft>) {
+                return m_left_value.value_or(supplier());
+            } else {
+                return m_right_value.value_or(supplier());
             }
         }
         template <typename TValueType>

--- a/cpp/include/result_t.h
+++ b/cpp/include/result_t.h
@@ -81,7 +81,7 @@ namespace win32::credential_store
         }
 
         template <typename TErrorCode>
-        [[nodiscard]] bool error_equals(TErrorCode value) const noexcept
+        [[nodiscard]] bool equals(TErrorCode value) const noexcept
         {
             auto const error_code = error_value_or_zero();
             if (error_code == SUCCESS) {
@@ -102,14 +102,12 @@ namespace win32::credential_store
             }
         }
 
-
-
         [[nodiscard]] constexpr std::string const& message() const noexcept
         {
             return m_error_message;
         }
 
-        [[nodiscard]] explicit operator bool() const
+        [[nodiscard]] constexpr explicit operator bool() const
         {
             return !m_error_code.has_value();
         }
@@ -131,7 +129,27 @@ namespace win32::credential_store
             , m_error_code(result_code)
         {
         }
-
     };
     
+    template <typename TErrorCode>
+    [[nodiscard]] bool operator==(result_t const& left, TErrorCode const& error_value)
+    {
+        return left.equals(error_value);
+    }
+    template <typename TErrorCode>
+    [[nodiscard]] bool operator!=(result_t const& left, TErrorCode const& error_value)
+    {
+        return !(left == error_value);
+    }
+
+    [[nodiscard]] constexpr bool operator==(result_t const& left, bool const success)
+    {
+        return static_cast<bool>(left) == success;
+    }
+    [[nodiscard]] constexpr bool operator!=(result_t const& left, bool const success)
+    {
+        return !(left == success);
+    }
+
+
 }

--- a/cpp/src/credential_manager_impl_using_traits.h
+++ b/cpp/src/credential_manager_impl_using_traits.h
@@ -76,7 +76,6 @@ namespace win32::credential_store
         }
         [[nodiscard]] result_t remove(wchar_t const* id, credential_type type) const override
         {
-            // static_cast<std::underlying_type<credential_type>::type>(type) -- move into CREDENTIAL_TRAITS
             if (auto const result = CREDENTIAL_TRAITS::cred_delete(id, type);
                 result != SUCCESS && result != ERROR_NOT_FOUND) {
                 return result_t::from_win32_error(result);
@@ -125,7 +124,6 @@ namespace win32::credential_store
             credentials_container container;
 
             auto const result = CREDENTIAL_TRAITS::cred_enumerate(filter, flags, container.count, container.credentials); 
-            // TODO: change method to return either vector, or result_t
             if (result != SUCCESS) {
                 return credentials_or_error_detail(result_t::from_win32_error(result));
             }
@@ -135,7 +133,6 @@ namespace win32::credential_store
             }
 
             return make_left<credentials_t, result_t>(std::move(matches));
-            //return credentials_or_error_detail(std::move(matches));
         }
 
     };

--- a/cpp/src/credential_store_cli/credential_executor.cpp
+++ b/cpp/src/credential_store_cli/credential_executor.cpp
@@ -97,7 +97,7 @@ void credential_executor::find(std::vector<std::string_view> const& arguments) c
             credential.has_value<win32::credential_store::credential<wchar_t>>()) {
             print_credential(credential.value<win32::credential_store::credential<wchar_t>>());
 
-        } else if (credential.value<result_t>().error_equals(ERROR_NOT_FOUND)) {
+        } else if (credential.value<result_t>().equals(ERROR_NOT_FOUND)) {
             wcout << id << L" not found." << endl;
 
         } else {


### PR DESCRIPTION
## Changes

- code tidy up - shifted code from credential_test to credential_builder - shifted code from credential_builder header to cpp file
- adding mock traits for manager tests - factory_tratis complete - files added for mock_credential_traits but no implementation yet
- moved unique_credential into traits - moved using statements into class level from namespace level so it can be part of the trait - further implementation of mock traits
- updated shared library CMakeLists.txt - now builds dll, includes not yet updated with any export details but definition has been added
- added header file with #define exports - added extra definition to shared library to further distinguish between static library and shared library
- added export usage to credential manager - added WIN32_CREDENTIAL_STORE_EXPORT to classes, functions, ... to be exported from shared library of credential manager - updated test project to use shared library
- added unit tests - make error_equals const - added unit tests for add_or_update in credential manager - moved make_credential to credential_builder
- start of update to find : ```vector<credential_t>``` - intention is to change the return value to ```either<vector<credential_t>, result_t>``` to allow returning error rather than throwing exception - additional unit tests for find : ```either<credential_t, result_t>``` - added make_credentials which creates a vector of credential_t, not sure if it'll actually be used or not
- reworked find : ```vector<credential_t>``` - updated find : ```vector<credentiaL_t>``` to return ```either<vector, result_t>``` to handle errors without the need for exceptions corrections to either - removed overloads using supplier - updated the remaining implementation to match value_or for optional -
- removed duplicate test
- either/result tweaks + unit tests - updated either to try and include value_or with supplier - not yet tested - added operator== and != for result_t - removed old comments/TODOs - added a few more tests and cleaned up a few others - will eventually rework the tests to use a test class to support setup, tear down and parameterised tests

## Tests

- primarily the existing and new unit tests