### PR TITLE
credential manager tests + cli test prep

### DIFF
--- a/cpp/src/credential_manager_impl_using_traits.h
+++ b/cpp/src/credential_manager_impl_using_traits.h
@@ -29,6 +29,8 @@ namespace win32::credential_store
     template <typename CREDENTIAL_TRAITS, typename CREDENTIAL_FACTORY_TRAITS>
     class credential_manager_impl_using_traits final : public credential_manager_impl
     {
+        static const DWORD SUCCESS = 0UL;
+
     public:
         [[nodiscard]] credentials_or_error_detail get_credentials() const override
         {
@@ -85,19 +87,40 @@ namespace win32::credential_store
         }
 
         explicit credential_manager_impl_using_traits() = default;
-        credential_manager_impl_using_traits(const credential_manager_impl_using_traits& other) = delete;
-        credential_manager_impl_using_traits(credential_manager_impl_using_traits&& other) noexcept = default;
-        credential_manager_impl_using_traits& operator=(const credential_manager_impl_using_traits& other) = delete;
-        credential_manager_impl_using_traits& operator=(credential_manager_impl_using_traits&& other) noexcept = default;
+        credential_manager_impl_using_traits(credential_manager_impl_using_traits const& other) = delete;
+        credential_manager_impl_using_traits& operator=(credential_manager_impl_using_traits const& other) = delete;
+        /// <summary>
+        /// Move constructor
+        /// </summary>
+        /// <param name="other">other object to move into this one</param>
+        /// <remarks>
+        /// see move operator=, following its behaviour in both cases for this class it's simple as there are no members
+        /// to be moved
+        /// </remarks>
+        credential_manager_impl_using_traits(credential_manager_impl_using_traits&& other) noexcept
+        {
+            static_cast<void>(other); // nothing to move
+        }
+        /// <summary>
+        /// Move operator
+        /// </summary>
+        /// <param name="other">other object to move into this one</param>
+        /// <returns>reference to this object</returns>
+        /// <remarks>
+        /// explicit implementation rather than = default because it was implicitly deleted otherwise despite existing,
+        /// likely something to do with the templates in use.  Further research required for now just making note of it
+        /// </remarks>
+        credential_manager_impl_using_traits& operator=(credential_manager_impl_using_traits&& other) noexcept
+        {
+            static_cast<void>(other); // nothing to move
+            return *this;
+        }
         ~credential_manager_impl_using_traits() override = default;
     private:
-        static const DWORD SUCCESS = 0UL;
-
         [[nodiscard]] static bool is_null_or_empty(wchar_t const *string)
         {
             return string == nullptr || wcslen(string) == 0;
         }
-
         [[nodiscard]] credentials_or_error_detail get_credentials(wchar_t const* filter, const bool search_all) const 
         {
             using credentials_t = std::vector<credential_t>;

--- a/cpp/src/credential_store_cli/CMakeLists.txt
+++ b/cpp/src/credential_store_cli/CMakeLists.txt
@@ -3,7 +3,7 @@ set (CMAKE_CXX_STANDARD 17)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-set (SOURCE "main.cpp" "credential_executor.cpp")
+set (SOURCE "main.cpp" "credential_executor.cpp" "cli_result_code.h")
 
 add_executable(${CLI_PROJECT_NAME} WIN32 ${SOURCE})
 

--- a/cpp/src/credential_store_cli/cli_result_code.h
+++ b/cpp/src/credential_store_cli/cli_result_code.h
@@ -13,32 +13,14 @@
 
 #pragma once
 
-#include <credential_manager_interface.h>
-#include <string_view>
-#include <functional>
-#include <vector>
-#include "cli_result_code.h"
-
 namespace win32::credential_store::cli
 {
-    using verb_processor = std::function<cli_result_code (std::vector<std::string_view> const&)>;
-    
-    class credential_executor final
+    enum class cli_result_code
     {
-    public:
-        explicit credential_executor(credential_manager_interface const& manager, std::wostream& output_stream);
-
-        [[nodiscard]] verb_processor get_operation(std::string_view const& verb) const;
-
-        [[nodiscard]] cli_result_code none(std::vector<std::string_view> const& arguments) const;
-        [[nodiscard]] cli_result_code add(std::vector<std::string_view> const& arguments) const;
-        [[nodiscard]] cli_result_code find(std::vector<std::string_view> const& arguments) const;
-        [[nodiscard]] cli_result_code list(std::vector<std::string_view> const& arguments) const;
-        [[nodiscard]] cli_result_code remove(std::vector<std::string_view> const& arguments) const;
-
-    private:
-        credential_manager_interface const& m_manager;
-        std::wostream& m_output_stream;
+        success = 0,
+        insufficient_arguments,
+        unrecognized_argument,
+        not_found,
     };
-
+    
 }

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SOURCE
  "mock_credential_factory_traits.cpp" 
  "mock_credential_traits.h" 
  "mock_credential_traits.cpp" 
- "invalid_test_setup_exception.h")
+ "invalid_test_setup_exception.h" "credential_manager_test_fixture.h" "credential_manager_test_fixture.cpp")
 
 add_executable(${TEST_PROJECT_NAME} WIN32 ${SOURCE})
 add_test(NAME ${TEST_PROJECT_NAME} COMMAND ${TEST_PROJECT_NAME})

--- a/cpp/test/credential_manager_test_fixture.cpp
+++ b/cpp/test/credential_manager_test_fixture.cpp
@@ -11,6 +11,9 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // 
 
+// ignore methods that may be static to keep up appearances of them being part of the fixture
+// ReSharper disable CppMemberFunctionMayBeStatic 
+
 #include "credential_manager_test_fixture.h"
 
 namespace win32::credential_store::tests
@@ -24,22 +27,18 @@ credential_manager_test_fixture::credential_manager_test_fixture()
 
 void credential_manager_test_fixture::SetUp()
 {
-    std::optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>> obj{std::nullopt};
-    //credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits> obj2;
-    std::optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>> obj2 = std::make_optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>>();
-    obj = std::move(obj2);
-    //obj = obj2;
-
-        //std::make_optional( credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>());
-    //m_manager = std::make_optional(credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>());
-    //m_manager = std::make_optional<credential_manager_test>();
-    //m_manager = std::make_optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>>();
-    m_manager = 
+    m_manager = credential_manager_test();
     m_credential = make_credential();
+
+    set_cred_delete_result(0UL);
+    set_cred_enumerate_result(0UL);
+    set_cred_read_result(0UL);
+    set_cred_write_result(0UL);
 }
 
 void credential_manager_test_fixture::TearDown()
 {
+    // nothing to tear down at this time...
 }
 
 wchar_t const* credential_manager_test_fixture::id() const noexcept
@@ -60,6 +59,23 @@ credential_manager_test& credential_manager_test_fixture::manager()
 credential_t& credential_manager_test_fixture::credential()
 {
     return m_credential.value();
+}
+
+void credential_manager_test_fixture::set_cred_read_result(DWORD const value) const noexcept
+{
+    mock_credential_traits::s_cred_read_result = value;
+}
+void credential_manager_test_fixture::set_cred_write_result(DWORD const value) const noexcept
+{
+    mock_credential_traits::s_cred_write_result = value;
+}
+void credential_manager_test_fixture::set_cred_enumerate_result(DWORD const value) const noexcept
+{
+    mock_credential_traits::s_cred_enumerate_result = value;
+}
+void credential_manager_test_fixture::set_cred_delete_result(DWORD const value) const noexcept
+{
+    mock_credential_traits::s_cred_delete_result = value;
 }
 
 }

--- a/cpp/test/credential_manager_test_fixture.cpp
+++ b/cpp/test/credential_manager_test_fixture.cpp
@@ -1,0 +1,65 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#include "credential_manager_test_fixture.h"
+
+namespace win32::credential_store::tests
+{
+
+credential_manager_test_fixture::credential_manager_test_fixture()
+    : m_id{L"ARBITRARY_IDENTIFIER"}
+    , m_type{credential_type::generic}
+{
+}
+
+void credential_manager_test_fixture::SetUp()
+{
+    std::optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>> obj{std::nullopt};
+    //credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits> obj2;
+    std::optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>> obj2 = std::make_optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>>();
+    obj = std::move(obj2);
+    //obj = obj2;
+
+        //std::make_optional( credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>());
+    //m_manager = std::make_optional(credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>());
+    //m_manager = std::make_optional<credential_manager_test>();
+    //m_manager = std::make_optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>>();
+    m_manager = 
+    m_credential = make_credential();
+}
+
+void credential_manager_test_fixture::TearDown()
+{
+}
+
+wchar_t const* credential_manager_test_fixture::id() const noexcept
+{
+    return m_id;
+}
+
+credential_type credential_manager_test_fixture::type() const noexcept
+{
+    return m_type;
+}
+
+credential_manager_test& credential_manager_test_fixture::manager()
+{
+    return m_manager.value();
+}
+
+credential_t& credential_manager_test_fixture::credential()
+{
+    return m_credential.value();
+}
+
+}

--- a/cpp/test/credential_manager_test_fixture.h
+++ b/cpp/test/credential_manager_test_fixture.h
@@ -1,0 +1,62 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable : 26495 26812)
+#include <gtest/gtest.h>
+#pragma warning(pop)
+
+#include "../src/credential_manager_impl_using_traits.h"
+
+#include <optional>
+#include "mock_credential_factory_traits.h"
+#include "mock_credential_traits.h"
+#include "credential_builder.h"
+#include <winerror.h>
+
+// it is defined but IDE sometimes complains its not
+#ifndef ERROR_NOT_FOUND
+#define ERROR_NOT_FOUND 1168L
+#endif
+
+namespace win32::credential_store::tests
+{
+    using credential_manager_test = credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>;
+
+    class credential_manager_test_fixture : public ::testing::Test
+    {
+    public:
+        using credential_t = credential<wchar_t>;
+    private:
+        std::optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>> m_manager{};
+        //std::optional<credential_manager_test> m_manager{};
+        std::optional<credential_t> m_credential{};
+        wchar_t const* const m_id;
+        credential_type const m_type;
+
+    public:
+        explicit credential_manager_test_fixture();
+
+        void SetUp() override;
+        void TearDown() override;
+
+        [[nodiscard]] wchar_t const* id() const noexcept;
+        [[nodiscard]] credential_type type() const noexcept;
+        [[nodiscard]] credential_manager_test& manager();
+        [[nodiscard]] credential_t& credential();
+    };
+
+    
+}

--- a/cpp/test/credential_manager_test_fixture.h
+++ b/cpp/test/credential_manager_test_fixture.h
@@ -40,9 +40,8 @@ namespace win32::credential_store::tests
     public:
         using credential_t = credential<wchar_t>;
     private:
-        std::optional<credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>> m_manager{};
-        //std::optional<credential_manager_test> m_manager{};
-        std::optional<credential_t> m_credential{};
+        std::optional<credential_manager_test> m_manager{std::nullopt};
+        std::optional<credential_t> m_credential{std::nullopt};
         wchar_t const* const m_id;
         credential_type const m_type;
 
@@ -56,6 +55,11 @@ namespace win32::credential_store::tests
         [[nodiscard]] credential_type type() const noexcept;
         [[nodiscard]] credential_manager_test& manager();
         [[nodiscard]] credential_t& credential();
+
+        void set_cred_read_result(DWORD const value) const noexcept;
+        void set_cred_write_result(DWORD const value) const noexcept;
+        void set_cred_enumerate_result(DWORD const value) const noexcept;
+        void set_cred_delete_result(DWORD const value) const noexcept;
     };
 
     

--- a/cpp/test/credential_manager_tests.cpp
+++ b/cpp/test/credential_manager_tests.cpp
@@ -11,27 +11,11 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // 
 
-#pragma warning(push)
-#pragma warning(disable : 26495 26812)
-#include <gtest/gtest.h>
-#pragma warning(pop)
-
-#include "../src/credential_manager_impl_using_traits.h"
-#include "mock_credential_factory_traits.h"
-#include "mock_credential_traits.h"
-#include "credential_builder.h"
-#include <winerror.h>
-
-// it is defined but IDE sometimes complains its not
-#ifndef ERROR_NOT_FOUND
-#define ERROR_NOT_FOUND 1168L
-#endif
+#include "credential_manager_test_fixture.h"
 
 namespace win32::credential_store::tests
 {
 
-using credential_manager_test = credential_manager_impl_using_traits<mock_credential_traits, mock_credential_factory_traits>;
-    
 TEST(credential_manager, add_or_update__returns_invalid_argument__id_is_empty)
 {
     auto const credential = make_credential();

--- a/cpp/test/credential_manager_tests.cpp
+++ b/cpp/test/credential_manager_tests.cpp
@@ -143,13 +143,11 @@ TEST(credential_manager, remove__by_object__returns_success__when_not_found)
 
     ASSERT_TRUE(result.is_success());
 }
-TEST(credential_manager, remove__by_object__returns_error__when_api_returns_error)
+TEST_F(credential_manager_test_fixture, remove__by_object__returns_error__when_api_returns_error)
 {
     mock_credential_traits::set_cred_delete_result(42UL);
-    credential_manager_test const manager;
-    auto const credential{make_credential()};
 
-    auto const result = manager.remove(credential);
+    auto const result = manager().remove(credential());
 
     ASSERT_EQ(result, 42UL);
 }

--- a/cpp/test/credential_manager_tests.cpp
+++ b/cpp/test/credential_manager_tests.cpp
@@ -16,136 +16,103 @@
 namespace win32::credential_store::tests
 {
 
-TEST(credential_manager, add_or_update__returns_invalid_argument__id_is_empty)
+TEST_F(credential_manager_test_fixture, add_or_update__returns_invalid_argument__id_is_empty)
 {
-    auto const credential = make_credential();
-    auto& id = const_cast<std::wstring&>(credential.get_id());
+    auto& id = const_cast<std::wstring&>(credential().get_id());
     id = L"";
 
-    credential_manager_test manager;
-
-    auto const result = manager.add_or_update(credential);
+    auto const result = manager().add_or_update(credential());
 
     ASSERT_EQ(result, std::errc::invalid_argument);
 }
-
-TEST(credential_manager, add_or_update__returns_invalid_argument__username_is_empty)
+TEST_F(credential_manager_test_fixture, add_or_update__returns_invalid_argument__username_is_empty)
 {
-    auto const credential = make_credential();
-    auto& username = const_cast<std::wstring&>(credential.get_username());
+    auto& username = const_cast<std::wstring&>(credential().get_username());
     username = L"";
 
-    credential_manager_test manager;
-
-    auto const result = manager.add_or_update(credential);
+    auto const result = manager().add_or_update(credential());
 
     ASSERT_EQ(result, std::errc::invalid_argument);
 }
-
-TEST(credential_manager, add_or_update__returns_error__api_returns_error)
+TEST_F(credential_manager_test_fixture, add_or_update__returns_error__api_returns_error)
 {
-    mock_credential_traits::set_cred_write_result(42UL);
-    credential_manager_test manager;
-    auto const credential{make_credential()};
+    set_cred_write_result(42UL);
 
-    auto const result = manager.add_or_update(credential);
+    auto const result = manager().add_or_update(credential());
 
     ASSERT_EQ(result, 42UL);
 }
 
-TEST(credential_manager, find__returns_matching_credential__when_api_returns_success)
+TEST_F(credential_manager_test_fixture, find__returns_matching_credential__when_api_returns_success)
 {
-    auto credential{make_credential()};
-    mock_credential_factory_traits::set_credential(&credential);
-    mock_credential_traits::set_cred_read_result(0UL);
-    credential_manager_test const manager;
-    auto const* id = L"ARBITRARY";
-    auto const type = credential_type::generic;
+    mock_credential_factory_traits::set_credential(&credential());
+    set_cred_read_result(0UL);
 
-    auto const match = manager.find(id, type).value<credential_t>();
+    auto const match = manager().find(id(), type()).value<credential_t>();
 
-    ASSERT_EQ(credential, match);
+    ASSERT_EQ(credential(), match);
 }
-TEST(credential_manager, find__returns_not_found__when_api_returns_not_found)
+TEST_F(credential_manager_test_fixture, find__returns_not_found__when_api_returns_not_found)
 {
-    mock_credential_traits::set_cred_read_result(ERROR_NOT_FOUND);
-    credential_manager_test const manager;
-    auto const* id = L"ARBITRARY";
-    auto const type = credential_type::generic;
+    set_cred_read_result(ERROR_NOT_FOUND);
 
-    auto const result = manager.find(id, type).value<result_t>();
+    auto const result = manager().find(id(), type()).value<result_t>();
 
     ASSERT_EQ(result, ERROR_NOT_FOUND);
 }
-
-TEST(credential_manager, find__returns_error__when_api_returns_error)
+TEST_F(credential_manager_test_fixture, find__returns_error__when_api_returns_error)
 {
-    mock_credential_traits::set_cred_read_result(42UL);
-    credential_manager_test const manager;
-    auto const* id = L"ARBITRARY";
-    auto const type = credential_type::generic;
+    set_cred_read_result(42UL);
 
-    auto const result = manager.find(id, type).value<result_t>();
+    auto const result = manager().find(id(), type()).value<result_t>();
 
     ASSERT_EQ(result, 42UL);
 }
 
-TEST(credential_manager, remove__by_id__returns_success__when_api_returns_success)
+TEST_F(credential_manager_test_fixture, remove__by_id__returns_success__when_api_returns_success)
 {
-    mock_credential_traits::set_cred_delete_result(0UL);
-    credential_manager_test const manager;
-    auto const* id = L"ARBITRARY";
-    auto const type = credential_type::generic;
+    set_cred_delete_result(0UL);
 
-    auto const result = manager.remove(id, type);
+    auto const result = manager().remove(id(), type());
 
     ASSERT_TRUE(result.is_success());
 }
-TEST(credential_manager, remove__by_id__returns_success__when_not_found)
+TEST_F(credential_manager_test_fixture, remove__by_id__returns_success__when_not_found)
 {
-    mock_credential_traits::set_cred_delete_result(ERROR_NOT_FOUND);
-    credential_manager_test const manager;
-    auto const* id = L"ARBITRARY";
-    auto const type = credential_type::generic;
+    set_cred_delete_result(ERROR_NOT_FOUND);
 
-    auto const result = manager.remove(id, type);
+    auto const result = manager().remove(id(), type());
 
     ASSERT_TRUE(result.is_success());
 }
-TEST(credential_manager, remove__by_id__returns_error__when_api_returns_error)
+TEST_F(credential_manager_test_fixture, remove__by_id__returns_error__when_api_returns_error)
 {
-    mock_credential_traits::set_cred_delete_result(42UL);
-    credential_manager_test const manager;
-    auto const* id = L"ARBITRARY";
-    auto const type = credential_type::generic;
+    set_cred_delete_result(42UL);
 
-    auto const result = manager.remove(id, type);
+    auto const result = manager().remove(id(), type());
 
     ASSERT_EQ(result, 42UL);
 }
-TEST(credential_manager, remove__by_object__returns_success__when_api_returns_success)
-{
-    mock_credential_traits::set_cred_delete_result(0UL);
-    credential_manager_test const manager;
-    auto const credential{make_credential()};
 
-    auto const result = manager.remove(credential);
+TEST_F(credential_manager_test_fixture, remove__by_object__returns_success__when_api_returns_success)
+{
+    set_cred_delete_result(0UL);
+
+    auto const result = manager().remove(credential());
 
     ASSERT_TRUE(result.is_success());
 }
-TEST(credential_manager, remove__by_object__returns_success__when_not_found)
+TEST_F(credential_manager_test_fixture, remove__by_object__returns_success__when_not_found)
 {
-    mock_credential_traits::set_cred_delete_result(ERROR_NOT_FOUND);
-    credential_manager_test const manager;
-    auto const credential{make_credential()};
+    set_cred_delete_result(ERROR_NOT_FOUND);
 
-    auto const result = manager.remove(credential);
+    auto const result = manager().remove(credential());
 
     ASSERT_TRUE(result.is_success());
 }
 TEST_F(credential_manager_test_fixture, remove__by_object__returns_error__when_api_returns_error)
 {
-    mock_credential_traits::set_cred_delete_result(42UL);
+    set_cred_delete_result(42UL);
 
     auto const result = manager().remove(credential());
 

--- a/cpp/test/mock_credential_traits.cpp
+++ b/cpp/test/mock_credential_traits.cpp
@@ -16,7 +16,6 @@
 
 namespace win32::credential_store::tests
 {
-    //using unique_credential_w = std::unique_ptr<CREDENTIALW, void (*)(CREDENTIALW*)>;  
     CREDENTIALW* MOCK_CREDENTIAL_ADDRESS = reinterpret_cast<CREDENTIALW*>(0x1234);
 
     mock_credential_traits::credential_t* mock_credential_traits::s_mock_result_ptr = nullptr;
@@ -50,11 +49,11 @@ namespace win32::credential_store::tests
     }
     void mock_credential_traits::credential_deleter(CREDENTIALW*)
     {
-        // ... ignore ...
+        // ... ignore, mock never allocates so nothing to delete ...
     }
     void mock_credential_traits::credential_deleter(CREDENTIALW**)
     {
-        // ... ignore ...
+        // ... ignore, mock never allocates so nothing to delete ...
     }
     DWORD mock_credential_traits::to_dword(credential_type const type)
     {


### PR DESCRIPTION
## Changes

- code tidy up - shifted code from credential_test to credential_builder - shifted code from credential_builder header to cpp file
- adding mock traits for manager tests - factory_tratis complete - files added for mock_credential_traits but no implementation yet
- moved unique_credential into traits - moved using statements into class level from namespace level so it can be part of the trait - further implementation of mock traits
- updated shared library CMakeLists.txt - now builds dll, includes not yet updated with any export details but definition has been added
- added header file with #define exports - added extra definition to shared library to further distinguish between static library and shared library
- added export usage to credential manager - added WIN32_CREDENTIAL_STORE_EXPORT to classes, functions, ... to be exported from shared library of credential manager - updated test project to use shared library
- added unit tests - make error_equals const - added unit tests for add_or_update in credential manager - moved make_credential to credential_builder
- start of update to find : ```vector<credential_t>``` - intention is to change the return value to ```either<vector<credential_t>, result_t>``` to allow returning error rather than throwing exception - additional unit tests for find : ```either<credential_t, result_t>``` - added make_credentials which creates a vector of credential_t, not sure if it'll actually be used or not
- reworked find : ```vector<credential_t>``` - updated find : ```vector<credentiaL_t>``` to return ```either<vector, result_t>``` to handle errors without the need for exceptions corrections to either - removed overloads using supplier - updated the remaining implementation to match value_or for optional -
- removed duplicate test
- either/result tweaks + unit tests - updated either to try and include value_or with supplier - not yet tested - added operator== and != for result_t - removed old comments/TODOs - added a few more tests and cleaned up a few others - will eventually rework the tests to use a test class to support setup, tear down and parameterised tests
- adding test fixture - checkpoint (code not yet compiling)
- test fixture now working - first test moved over into fixture reducing the duplicate setup code, may add parameterised test just to have one
- shifted tests into fixture class
- update credential_executor - takes wostream to write to, in theory to allow testing which at least ignores or checks that something was written too - updates around credential cli passing a stream to write too and returning results to allow for some degree of testing

## Tests

- primarily unit tests
