### PR TITLE
additional unit tests and bug fixes

### DIFF
--- a/cpp/src/credential_store_cli/cli_result_code.h
+++ b/cpp/src/credential_store_cli/cli_result_code.h
@@ -21,6 +21,7 @@ namespace win32::credential_store::cli
         insufficient_arguments,
         unrecognized_argument,
         not_found,
+        error_occurred,
     };
     
 }

--- a/cpp/src/credential_store_cli/credential_executor.cpp
+++ b/cpp/src/credential_store_cli/credential_executor.cpp
@@ -25,8 +25,6 @@ using std::endl;
 namespace win32::credential_store::cli
 {
 
-[[nodiscard]] verb_type get_verb_type(std::string_view const& verb);
-[[nodiscard]] credential_type get_credential_type(std::string_view const& type);
 void print_unreognized_type();
 
 void print_credential(credential<wchar_t> const& credential, std::wostream& output_stream) {
@@ -187,21 +185,21 @@ credential_type get_credential_type(std::string_view const& type)
     std::string upper_type(type.size(), '\0');
     std::transform(begin(type), end(type), begin(upper_type), to_upper);
 
-    if (upper_type.find("GENERIC", 0) != std::string::npos)
+    if (upper_type == "GENERIC")
         return credential_type::generic;
-    if (upper_type.find("DOMAIN_CERTIFICATE", 0) != std::string::npos)
+    if (upper_type == "DOMAIN_CERTIFICATE")
         return credential_type::domain_certificate;
-    if (upper_type.find("DOMAIN_EXTENDED", 0) != std::string::npos)
+    if (upper_type == "DOMAIN_EXTENDED")
         return credential_type::domain_extended;
-    if (upper_type.find("DOMAIN_PASSWORD", 0) != std::string::npos)
+    if (upper_type == "DOMAIN_PASSWORD")
         return credential_type::domain_password;
-    if (upper_type.find("DOMAIN_VISIBLE_PASSWORD", 0) != std::string::npos)
+    if (upper_type == "DOMAIN_VISIBLE_PASSWORD")
         return credential_type::domain_visible_password;
-    if (upper_type.find("GENERIC_CERTIFICATE", 0) != std::string::npos)
+    if (upper_type == "GENERIC_CERTIFICATE")
         return credential_type::generic_certificate;
-    if (upper_type.find("MAXIMUM", 0) != std::string::npos)
+    if (upper_type == "MAXIMUM")
         return credential_type::maximum;
-    if (upper_type.find("MAXIMUM_EX", 0) != std::string::npos)
+    if (upper_type == "MAXIMUM_EX")
         return credential_type::maximum_ex;
 
     return credential_type::unknown;

--- a/cpp/src/credential_store_cli/credential_executor.h
+++ b/cpp/src/credential_store_cli/credential_executor.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <vector>
 #include "cli_result_code.h"
+#include "verb_type.h"
 
 namespace win32::credential_store::cli
 {
@@ -42,5 +43,8 @@ namespace win32::credential_store::cli
         credential_manager_interface const& m_manager;
         std::wostream& m_output_stream;
     };
+
+    [[nodiscard]] verb_type get_verb_type(std::string_view const& verb);
+    [[nodiscard]] credential_type get_credential_type(std::string_view const& type);
 
 }

--- a/cpp/test/credential_executor_test_fixture.h
+++ b/cpp/test/credential_executor_test_fixture.h
@@ -20,7 +20,6 @@
 
 #include "mock_credential_factory_traits.h"
 #include "mock_credential_traits.h"
-#include "credential_builder.h"
 #include <winerror.h>
 #include "../src/credential_store_cli/credential_executor.h"
 #include "../src/credential_manager_impl_using_traits.h"
@@ -55,10 +54,16 @@ namespace win32::credential_store::tests
         std::wostream m_stream;
         mock_credential_manager m_manager;
         cli::credential_executor m_executor;
+
+        static void set_cred_read_result(DWORD const value) noexcept;
+        static void set_cred_write_result(DWORD const value) noexcept;
+        static void set_cred_enumerate_result(DWORD const value) noexcept;
+        static void set_cred_delete_result(DWORD const value) noexcept;
     public:
         void SetUp() override;
         void TearDown() override;
 
+        [[nodiscard]] mock_credential_manager const& manager() const;
         [[nodiscard]] cli::credential_executor const& executor() const;
         [[nodiscard]] std::wostream& stream();
 


### PR DESCRIPTION
## Changes

- unit tests for credential_executor
- additional unit tests for credential_executor - added error_code to cli_result_code enum to represent the api returning error rather than an issue with arguments to the executor
- addressed a parsing bug in get_credential_type, changed use of find with == operator

## Tests

- unit testing
