### PR TITLE
added synchronize around use of advapi32 library

### DIFF
--- a/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/internal/CriticalCredentialHandleFactory.java
+++ b/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/internal/CriticalCredentialHandleFactory.java
@@ -7,6 +7,12 @@ import com.sun.jna.ptr.PointerByReference;
  * Factory used to construct {@code CriticalCredentialHandle}
  */
 public interface CriticalCredentialHandleFactory {
+
+    /**
+     * Returns an empty CriticalCredentialHandler, used to represent failure
+     */
+    CriticalCredentialHandle empty();
+
     /**
      * {@code CriticalCredentialHandle} builder
      * @param handle critical handle to wrap in {@code CriticalCredentialHandle}

--- a/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/internal/Win32CriticalCredentialHandleFactory.java
+++ b/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/internal/Win32CriticalCredentialHandleFactory.java
@@ -31,6 +31,15 @@ public class Win32CriticalCredentialHandleFactory implements CriticalCredentialH
      * {@inheritDoc}
      */
     @Override
+    public CriticalCredentialHandle empty()
+    {
+        return new Win32CriticalCredentialHandle(advapi32, (PointerByReference) null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public CriticalCredentialHandle fromPointerByReference(PointerByReference handle) {
         return new Win32CriticalCredentialHandle(advapi32, handle);
     }


### PR DESCRIPTION
added synchronize around use of advapi32 library
- documentation doesn't mention thread safety so lets not risk it,
should probably do the same in the C++ and C# impl's