### PR TITLE
Java + C# updates

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: '5.0.100'
     - name: Install dependencies
       run: dotnet restore
       working-directory: ${{env.working-directory}}

--- a/CSharp/CredentialStore.Cli/CredentialStore.Cli.csproj
+++ b/CSharp/CredentialStore.Cli/CredentialStore.Cli.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Moreland.Security.Win32.CredentialStore.Cli</RootNamespace>
     <AssemblyName>CredentialStore.Cli</AssemblyName>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <Authors>Terry Moreland</Authors>
     <Company />

--- a/CSharp/CredentialStore.DependencyInjection.Tests/CredentialStore.DependencyInjection.Tests.csproj
+++ b/CSharp/CredentialStore.DependencyInjection.Tests/CredentialStore.DependencyInjection.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <RootNamespace>Moreland.Security.Win32.CredentialStore.DependencyInjection.Tests</RootNamespace>
     <AssemblyName>Moreland.Security.Win32.CredentialStore.DependencyInjection.Tests</AssemblyName>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <Authors>Terry Moreland</Authors>

--- a/CSharp/CredentialStore.DependencyInjection/CredentialStore.DependencyInjection.csproj
+++ b/CSharp/CredentialStore.DependencyInjection/CredentialStore.DependencyInjection.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>8</LangVersion>
+    <TargetFrameworks>net5.0</TargetFrameworks>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
 
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/CSharp/CredentialStore.Tests/CredentialStore.Tests.csproj
+++ b/CSharp/CredentialStore.Tests/CredentialStore.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Moreland.Security.Win32.CredentialStore.Tests</RootNamespace>
     <AssemblyName>Moreland.Security.Win32.CredentialStore.Tests</AssemblyName>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <Authors>Terry Moreland</Authors>

--- a/CSharp/CredentialStore/Credential.cs
+++ b/CSharp/CredentialStore/Credential.cs
@@ -86,7 +86,7 @@ namespace Moreland.Security.Win32.CredentialStore
             LastUpdated = lastUpdated;
 
             var invalidPropertyName = GetInvalidArgumentNameOrEmpty();
-            if (invalidPropertyName is not { Length: 0 })
+            if (!string.IsNullOrEmpty(invalidPropertyName))
                 throw new ArgumentException("one or more parameters have invalid values", invalidPropertyName);
         }
 

--- a/CSharp/CredentialStore/Credential.cs
+++ b/CSharp/CredentialStore/Credential.cs
@@ -56,7 +56,7 @@ namespace Moreland.Security.Win32.CredentialStore
             highBits <<= 32;
             LastUpdated = DateTime.FromFileTime(highBits + (uint)credential.LastWritten.dwLowDateTime);
 
-            if (GetInvalidArgumentNameOrEmpty() is not { Length: > 0})
+            if (GetInvalidArgumentNameOrEmpty() is not { Length: 0})
                 throw new ArgumentException("invalid settings", nameof(credential));
         }
 
@@ -86,7 +86,7 @@ namespace Moreland.Security.Win32.CredentialStore
             LastUpdated = lastUpdated;
 
             var invalidPropertyName = GetInvalidArgumentNameOrEmpty();
-            if (invalidPropertyName is not { Length: > 0 })
+            if (invalidPropertyName is not { Length: 0 })
                 throw new ArgumentException("one or more parameters have invalid values", invalidPropertyName);
         }
 

--- a/CSharp/CredentialStore/Credential.cs
+++ b/CSharp/CredentialStore/Credential.cs
@@ -56,7 +56,7 @@ namespace Moreland.Security.Win32.CredentialStore
             highBits <<= 32;
             LastUpdated = DateTime.FromFileTime(highBits + (uint)credential.LastWritten.dwLowDateTime);
 
-            if (!string.IsNullOrEmpty(GetInvalidArgumentNameOrEmpty()))
+            if (GetInvalidArgumentNameOrEmpty() is not { Length: > 0})
                 throw new ArgumentException("invalid settings", nameof(credential));
         }
 
@@ -86,7 +86,7 @@ namespace Moreland.Security.Win32.CredentialStore
             LastUpdated = lastUpdated;
 
             var invalidPropertyName = GetInvalidArgumentNameOrEmpty();
-            if (!string.IsNullOrEmpty(invalidPropertyName))
+            if (invalidPropertyName is not { Length: > 0 })
                 throw new ArgumentException("one or more parameters have invalid values", invalidPropertyName);
         }
 

--- a/CSharp/CredentialStore/CredentialStore.csproj
+++ b/CSharp/CredentialStore/CredentialStore.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>8</LangVersion>
+    <TargetFrameworks>net5.0</TargetFrameworks>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
 
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/java/credentialstore-cli/pom.xml
+++ b/java/credentialstore-cli/pom.xml
@@ -36,6 +36,7 @@
                 <configuration>
                     <argLine>
                         --add-opens moreland.win32.credentialstore.cli/moreland.win32.credentialstore.cli=ALL-UNNAMED
+                        --add-opens moreland.win32.credentialstore/moreland.win32.credentialstore.cli.internal=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/Credential.java
+++ b/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/Credential.java
@@ -133,10 +133,11 @@ public final class Credential {
 
         Credential that = (Credential) o;
 
-        return id.equals(that.id) &&
-                username.equals(that.username) &&
-                type == that.type &&
-                persistenceType == that.persistenceType;
+        return 
+            id.equals(that.id) &&
+            username.equals(that.username) &&
+            type == that.type &&
+            persistenceType == that.persistenceType;
     }
 
     /**

--- a/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/internal/Win32CriticalCredentialHandle.java
+++ b/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/internal/Win32CriticalCredentialHandle.java
@@ -35,7 +35,7 @@ public final class Win32CriticalCredentialHandle implements CriticalCredentialHa
             ? credentialPtr.getValue()
             : Pointer.NULL;
 
-        this.credential = !ptr.equals(Pointer.NULL)
+        this.credential = ptr != null 
             ? Optional.of(new Credential(ptr))
             : Optional.empty();
     }

--- a/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/internal/Win32NativeInteropBridge.java
+++ b/java/credentialstore-service/src/main/java/moreland/win32/credentialstore/internal/Win32NativeInteropBridge.java
@@ -23,7 +23,7 @@ import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.WString;
 
 import moreland.win32.credentialstore.CredentialType;
-
+import moreland.win32.credentialstore.Guard;
 import moreland.win32.credentialstore.structures.Credential;
 
 final class Win32NativeInteropBridge implements NativeInteropBridge {
@@ -43,15 +43,12 @@ final class Win32NativeInteropBridge implements NativeInteropBridge {
      */
     public Win32NativeInteropBridge(Advapi32Library advapi32, CriticalCredentialHandleFactory criticalCredentialHandleFactory) {
         super();
+
+        Guard.againstNull(advapi32, "advapi32");
+        Guard.againstNull(criticalCredentialHandleFactory, "criticalCredentialHandleFactory");
+
         this.advapi32 = advapi32;
         this.criticalCredentialHandleFactory = criticalCredentialHandleFactory;
-
-        if (this.advapi32 == null) {
-            throw new IllegalArgumentException("advapi cannot be null");
-        }
-        if (this.criticalCredentialHandleFactory == null) {
-            throw new IllegalArgumentException("critcicalCredentialFactory is null");
-        }
     }
 
     /**

--- a/java/credentialstore-service/src/test/java/moreland/win32/credentialstore/CredentialTests.java
+++ b/java/credentialstore-service/src/test/java/moreland/win32/credentialstore/CredentialTests.java
@@ -116,6 +116,30 @@ class CredentialTests {
         assertNotEquals(first, second);
     }
 
+    @ParameterizedTest(name = "{index} => {0}")
+    @MethodSource("equalsTestProvider")
+    void hashCode_returnsSameValueForEqualObjects(Pair<String, CredentialFlag> pair) {
+        var first = new Credential(id, username, pair.item1, pair.item2, type, CredentialPersistence.LOCAL_MACHINE, lastUpdated);
+        var second = new Credential(id, username, pair.item1, pair.item2, type, CredentialPersistence.LOCAL_MACHINE, lastUpdated.plus(1, ChronoUnit.DAYS));
+        
+        int firstHashCode = first.hashCode();
+        int secondHashCode = second.hashCode();
+
+        assertEquals(firstHashCode, secondHashCode);
+    }
+
+    @ParameterizedTest(name = "{index} => {0}")
+    @MethodSource("equalsTestProvider")
+    void hashCode_returnsDifferentValuesForNonEqualObjects(Pair<String, CredentialFlag> pair) {
+        var first = new Credential(id, "user1", pair.item1, pair.item2, type, persistence, lastUpdated);
+        var second = new Credential(id, "user2", pair.item1, pair.item2, type, persistence, lastUpdated.plus(1, ChronoUnit.DAYS));
+
+        int firstHashCode = first.hashCode();
+        int secondHashCode = second.hashCode();
+
+        assertNotEquals(firstHashCode, secondHashCode);
+    }
+
     private static Stream<Pair<String, CredentialFlag>> equalsTestProvider() {
         return Arrays.stream(CredentialFlag.class.getEnumConstants())
                 .map(flag -> new Pair<>("alt password" + flag.toString(), flag));

--- a/java/credentialstore-service/src/test/java/moreland/win32/credentialstore/internal/Win32CriticalCredentialHandleFactoryTests.java
+++ b/java/credentialstore-service/src/test/java/moreland/win32/credentialstore/internal/Win32CriticalCredentialHandleFactoryTests.java
@@ -12,46 +12,37 @@
 //
 package moreland.win32.credentialstore.internal;
 
-import com.sun.jna.Pointer;
-import com.sun.jna.ptr.PointerByReference;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import moreland.win32.credentialstore.Guard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class Win32CriticalCredentialHandleFactory implements CriticalCredentialHandleFactory {
+@ExtendWith(MockitoExtension.class)
+class Win32CriticalCredentialHandleFactoryTests {
+    
+    @Mock
+    private Advapi32Library advapi32;
+    private Win32CriticalCredentialHandleFactory factory;
 
-    private final Advapi32Library advapi32;
-
-    public Win32CriticalCredentialHandleFactory() {
-        this(Advapi32Library.INSTANCE);
+    @BeforeEach
+    void setup() {
+        factory = new Win32CriticalCredentialHandleFactory(advapi32);
     }
 
-    public Win32CriticalCredentialHandleFactory(Advapi32Library advapi32) {
-        Guard.againstNull(advapi32, "advapi32");
-        this.advapi32 = advapi32;
+    @Test
+    void constructor_throwsIllegalArgumentException_whenAdvapi32IsNull() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> new Win32CriticalCredentialHandleFactory((Advapi32Library)null));
+        assertTrue(ex.getMessage().contains("advapi32"));
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CriticalCredentialHandle empty()
-    {
-        return new Win32CriticalCredentialHandle(advapi32, (PointerByReference) null);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CriticalCredentialHandle fromPointerByReference(PointerByReference handle) {
-        return new Win32CriticalCredentialHandle(advapi32, handle);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CriticalCredentialHandle fromPointer(Pointer pointer) {
-        return new Win32CriticalCredentialHandle(advapi32, pointer);
+    
+    @Test
+    void empty_returnsEmptyCriticalCredentialHandle_always() {
+        var emptyHandle = factory.empty();
+        assertFalse(emptyHandle.isPresent());
     }
 }

--- a/java/credentialstore-service/src/test/java/moreland/win32/credentialstore/internal/Win32NativeInteropBridgeTests.java
+++ b/java/credentialstore-service/src/test/java/moreland/win32/credentialstore/internal/Win32NativeInteropBridgeTests.java
@@ -1,0 +1,46 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+package moreland.win32.credentialstore.internal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class Win32NativeInteropBridgeTests {
+
+    @Mock
+    Advapi32Library advapi32;
+
+    @Mock
+    CriticalCredentialHandleFactory criticalCredentialHandleFactory;
+
+    @Test
+    void constructor_throwsIllegalArgumentException_whenAdvapi32IsNull() {
+        var ex = assertThrows(IllegalArgumentException.class, 
+            () -> new Win32NativeInteropBridge((Advapi32Library) null, criticalCredentialHandleFactory));
+        assertTrue(ex.getMessage().contains("advapi32"));
+    }
+    
+    @Test
+    void constructor_throwsIllegalArgumentException_whenCriticalCredentialHandleFactoryIsNull() {
+        var ex = assertThrows(IllegalArgumentException.class, 
+            () -> new Win32NativeInteropBridge(advapi32, (CriticalCredentialHandleFactory) null));
+        assertTrue(ex.getMessage().contains("criticalCredentialHandleFactory"));
+
+    }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -53,6 +53,18 @@
             <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.6.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
## Changes

- updating project to target net5.0 - dropping support of netcoreapp3.1 and earlier versions - upping language version to 9
- change dotnet core 3.1 to  net5.0
- moved from string.isNullOrEmpty to pattern matching
- reworked pattern matching - tempted to say IsNullOrEmpty is more appropriate for this case but playing with pattern matching none the less
- mix of pattern matching + nullorempty - pattern matching works in this case provided the error state is empty string, it won't handle null while NullOrEmpty will
- adding unit tests - some fixes for bugs found during development of tests

## Tests

for C# running the existing tests
for Java, newly added and existing tests