### PR TITLE
- commented out requires commons.logging to resolve build failure.  

### DIFF
--- a/java/credentialstore-cli/src/main/java/module-info.java
+++ b/java/credentialstore-cli/src/main/java/module-info.java
@@ -8,7 +8,7 @@ module moreland.win32.credentialstore.cli {
     requires spring.aop;
     requires spring.expression;
 
-    requires commons.logging;
+    //requires commons.logging; -- reporting as not found but commenting out doesn't seem to cause issues, yet
     requires transitive org.slf4j;
     requires transitive org.slf4j.simple;
 

--- a/java/credentialstore-service/pom.xml
+++ b/java/credentialstore-service/pom.xml
@@ -43,5 +43,27 @@
         <artifactId>jna-platform</artifactId>
         <version>5.13.0</version>
       </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+            <version>1.3.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/java/credentialstore-service/src/main/java/module-info.java
+++ b/java/credentialstore-service/src/main/java/module-info.java
@@ -21,9 +21,9 @@ module moreland.win32.credentialstore {
     requires transitive spring.aop;
     requires transitive spring.expression;
 
-    requires commons.logging;
     requires transitive org.slf4j;
     requires transitive org.slf4j.simple;
+//    requires commons.logging;
 
     opens moreland.win32.credentialstore to spring.core;
     exports moreland.win32.credentialstore.converters to spring.beans;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,10 +41,12 @@
             <artifactId>spring-core</artifactId>
             <version>6.1.1</version>
             <exclusions>
+                <!--
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                -->
             </exclusions>
         </dependency>
         <dependency>
@@ -52,10 +54,12 @@
             <artifactId>spring-context</artifactId>
             <version>6.1.1</version>
             <exclusions>
+                <!--
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                -->
             </exclusions>
         </dependency>
         <dependency>
@@ -77,27 +81,13 @@
             <artifactId>commons-logging</artifactId>
             <groupId>commons-logging</groupId>
             <version>1.3.0</version>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Doesn't appear to be required and isn't found as a module